### PR TITLE
Add ShiftWeightSettings management with routing and persistence

### DIFF
--- a/src/main/java/com/shiftmanagerserver/MainVerticle.java
+++ b/src/main/java/com/shiftmanagerserver/MainVerticle.java
@@ -2,10 +2,7 @@ package com.shiftmanagerserver;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import com.shiftmanagerserver.handlers.AuthHandler;
-import com.shiftmanagerserver.handlers.ConstraintHandler;
-import com.shiftmanagerserver.handlers.ShiftHandler;
-import com.shiftmanagerserver.handlers.UserHandler;
+import com.shiftmanagerserver.handlers.*;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.ext.web.Router;
@@ -20,15 +17,17 @@ public class MainVerticle extends AbstractVerticle {
     private final ConstraintHandler constraintHandler;
     private final AuthHandler authHandler;
     private final ShiftHandler shiftHandler;
+    private final ShiftWeightSettingsHandler shiftWeightSettingsHandler;
 
     @Inject
     public MainVerticle(@Named("application.port") Integer port, Router router,
-                        UserHandler userHandler, AuthHandler authHandler, ConstraintHandler constraintHandler, ShiftHandler shiftHandler) {
+                        UserHandler userHandler, AuthHandler authHandler, ConstraintHandler constraintHandler, ShiftHandler shiftHandler, ShiftWeightSettingsHandler shiftWeightSettingsHandler) {
         this.port = port;
         this.userHandler = userHandler;
         this.authHandler = authHandler;
         this.constraintHandler = constraintHandler;
         this.shiftHandler = shiftHandler;
+        this.shiftWeightSettingsHandler = shiftWeightSettingsHandler;
         this.router = router;
         this.logger = LoggerFactory.getLogger(MainVerticle.class);
     }
@@ -55,6 +54,7 @@ public class MainVerticle extends AbstractVerticle {
         userHandler.addRoutes(router);
         constraintHandler.addRoutes(router);
         shiftHandler.addRoutes(router);
+        shiftWeightSettingsHandler.addRoutes(router);
     }
 
 }

--- a/src/main/java/com/shiftmanagerserver/entities/Day.java
+++ b/src/main/java/com/shiftmanagerserver/entities/Day.java
@@ -1,0 +1,40 @@
+package com.shiftmanagerserver.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Day {
+    SUNDAY("ראשון"),
+    MONDAY("שני"),
+    TUESDAY("שלישי"),
+    WEDNESDAY("רביעי"),
+    THURSDAY("חמישי"),
+    FRIDAY("שישי"),
+    SATURDAY("שבת");
+
+    private final String hebrewName;
+
+    Day(String hebrewName) {
+        this.hebrewName = hebrewName;
+    }
+
+    @JsonCreator
+    public static Day fromHebrewName(String name) {
+        for (Day day : values()) {
+            if (day.hebrewName.equals(name)) {
+                return day;
+            }
+        }
+        throw new IllegalArgumentException("Unknown Hebrew day: " + name);
+    }
+
+    @JsonValue
+    public String getHebrewName() {
+        return hebrewName;
+    }
+
+    @Override
+    public String toString() {
+        return hebrewName;
+    }
+}

--- a/src/main/java/com/shiftmanagerserver/entities/ShiftWeight.java
+++ b/src/main/java/com/shiftmanagerserver/entities/ShiftWeight.java
@@ -1,0 +1,41 @@
+package com.shiftmanagerserver.entities;
+
+public class ShiftWeight {
+    private Day day;
+    private ShiftType shiftType;
+    private int weight;
+
+    public ShiftWeight() {
+    }
+
+    public ShiftWeight(Day day, ShiftType shiftType, int weight) {
+        this.day = day;
+        this.shiftType = shiftType;
+        this.weight = weight;
+    }
+
+    public Day getDay() {
+        return day;
+    }
+
+    public void setDay(Day day) {
+        this.day = day;
+    }
+
+    public ShiftType getShiftType() {
+        return shiftType;
+    }
+
+    public void setShiftType(ShiftType shiftType) {
+        this.shiftType = shiftType;
+    }
+
+    public int getWeight() {
+        return weight;
+    }
+
+    public void setWeight(int weight) {
+        this.weight = weight;
+    }
+}
+

--- a/src/main/java/com/shiftmanagerserver/entities/ShiftWeightPreset.java
+++ b/src/main/java/com/shiftmanagerserver/entities/ShiftWeightPreset.java
@@ -1,0 +1,33 @@
+package com.shiftmanagerserver.entities;
+
+import java.util.List;
+
+public class ShiftWeightPreset {
+    private String name;
+    private List<ShiftWeight> weights;
+
+    public ShiftWeightPreset() {
+    }
+
+    public ShiftWeightPreset(String name, List<ShiftWeight> weights) {
+        this.name = name;
+        this.weights = weights;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<ShiftWeight> getWeights() {
+        return weights;
+    }
+
+    public void setWeights(List<ShiftWeight> weights) {
+        this.weights = weights;
+    }
+}
+

--- a/src/main/java/com/shiftmanagerserver/entities/ShiftWeightSettings.java
+++ b/src/main/java/com/shiftmanagerserver/entities/ShiftWeightSettings.java
@@ -1,0 +1,32 @@
+package com.shiftmanagerserver.entities;
+
+import java.util.Map;
+
+public class ShiftWeightSettings {
+    private String currentPreset;
+    private Map<String, ShiftWeightPreset> presets;
+
+    public ShiftWeightSettings() {
+    }
+
+    public ShiftWeightSettings(String currentPreset, Map<String, ShiftWeightPreset> presets) {
+        this.currentPreset = currentPreset;
+        this.presets = presets;
+    }
+
+    public String getCurrentPreset() {
+        return currentPreset;
+    }
+
+    public void setCurrentPreset(String currentPreset) {
+        this.currentPreset = currentPreset;
+    }
+
+    public Map<String, ShiftWeightPreset> getPresets() {
+        return presets;
+    }
+
+    public void setPresets(Map<String, ShiftWeightPreset> presets) {
+        this.presets = presets;
+    }
+}

--- a/src/main/java/com/shiftmanagerserver/handlers/ShiftWeightSettingsHandler.java
+++ b/src/main/java/com/shiftmanagerserver/handlers/ShiftWeightSettingsHandler.java
@@ -1,0 +1,71 @@
+package com.shiftmanagerserver.handlers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shiftmanagerserver.entities.ShiftWeightPreset;
+import com.shiftmanagerserver.entities.ShiftWeightSettings;
+import com.shiftmanagerserver.service.ShiftWeightSettingsService;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class ShiftWeightSettingsHandler implements Handler {
+    private final ShiftWeightSettingsService service;
+    private final ObjectMapper objectMapper;
+
+    public ShiftWeightSettingsHandler() {
+        this.service = new ShiftWeightSettingsService();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public void handleGetSettings(RoutingContext ctx) {
+        ShiftWeightSettings settings = service.getSettings();
+        ctx.response()
+                .putHeader("Content-Type", "application/json")
+                .end(JsonObject.mapFrom(settings).encode());
+    }
+
+    public void handleSavePreset(RoutingContext ctx) {
+        try {
+            ShiftWeightPreset shiftWeightPreset = objectMapper.readValue(ctx.body().asString(), ShiftWeightPreset.class);
+            service.addPreset(shiftWeightPreset);
+            ctx.response()
+                    .setStatusCode(200)
+                    .putHeader("Content-Type", "application/json")
+                    .end(new JsonObject().put("message", "Presets saved").encode());
+        } catch (Exception e) {
+            ctx.response()
+                    .setStatusCode(400)
+                    .putHeader("Content-Type", "application/json")
+                    .end(new JsonObject().put("error", "Invalid data").encode());
+        }
+    }
+
+    public void handleSetCurrentPreset(RoutingContext ctx) {
+        try {
+            JsonObject json = ctx.body().asJsonObject();
+            String currentPreset = json.getString("currentPreset");
+            if (currentPreset == null) throw new IllegalArgumentException();
+            if (service.getSettings().getPresets().keySet().stream()
+                    .noneMatch(presetName -> presetName.equals(currentPreset))) {
+                throw new IllegalArgumentException("Preset not found");
+            }
+            service.setCurrentPreset(currentPreset);
+            ctx.response()
+                    .setStatusCode(200)
+                    .putHeader("Content-Type", "application/json")
+                    .end(new JsonObject().put("message", "Current preset set").encode());
+        } catch (Exception e) {
+            ctx.response()
+                    .setStatusCode(400)
+                    .putHeader("Content-Type", "application/json")
+                    .end(new JsonObject().put("error", "Invalid data").encode());
+        }
+    }
+
+    @Override
+    public void addRoutes(Router router) {
+        router.get("/shift-weight-settings").handler(this::handleGetSettings);
+        router.post("/shift-weight-settings/preset").handler(this::handleSavePreset);
+        router.post("/shift-weight-settings/current-preset").handler(this::handleSetCurrentPreset);
+    }
+}

--- a/src/main/java/com/shiftmanagerserver/service/ShiftWeightSettingsService.java
+++ b/src/main/java/com/shiftmanagerserver/service/ShiftWeightSettingsService.java
@@ -1,0 +1,61 @@
+package com.shiftmanagerserver.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shiftmanagerserver.entities.ShiftWeightPreset;
+import com.shiftmanagerserver.entities.ShiftWeightSettings;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ShiftWeightSettingsService {
+    private static final String SETTINGS_FILE = "shift_weight_settings.json";
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private ShiftWeightSettings settings;
+
+    public ShiftWeightSettingsService() {
+        loadSettings();
+    }
+
+    public ShiftWeightSettings getSettings() {
+        return settings;
+    }
+
+    public void saveSettings(ShiftWeightSettings newSettings) {
+        this.settings = newSettings;
+        saveToFile();
+    }
+
+    public void addPreset(ShiftWeightPreset preset) {
+        if (settings.getPresets() == null) {
+            settings.setPresets(new java.util.HashMap<>());
+        }
+        settings.getPresets().put(preset.getName(), preset);
+        saveToFile();
+    }
+
+    public void setCurrentPreset(String currentPreset) {
+        settings.setCurrentPreset(currentPreset);
+        saveToFile();
+    }
+
+    private void loadSettings() {
+        File file = new File(SETTINGS_FILE);
+        if (file.exists()) {
+            try {
+                settings = objectMapper.readValue(file, ShiftWeightSettings.class);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to load shift weight settings", e);
+            }
+        } else {
+            settings = new ShiftWeightSettings();
+        }
+    }
+
+    private void saveToFile() {
+        try {
+            objectMapper.writeValue(new File(SETTINGS_FILE), settings);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to save shift weight settings", e);
+        }
+    }
+}


### PR DESCRIPTION
- Introduced `ShiftWeightSettings`, `ShiftWeightPreset`, and `ShiftWeight` entities to define weight configurations.
- Added a new `ShiftWeightSettingsHandler` implementing `Handler` to manage shift weight settings routes.
- Implemented `ShiftWeightSettingsService` for persisting and loading weight settings from JSON files.
- Updated `MainVerticle` to integrate `ShiftWeightSettingsHandler` for route binding.